### PR TITLE
Testing Edit Methods: Implemented & Unit Tested EditBoardName

### DIFF
--- a/FakeTrello.Tests/DAL/FakeTrelloRepoTests.cs
+++ b/FakeTrello.Tests/DAL/FakeTrelloRepoTests.cs
@@ -47,6 +47,8 @@ namespace FakeTrello.Tests.DAL
             mock_boards_set.Setup(b => b.Remove(It.IsAny<Board>())).Callback((Board board) => fake_board_table.Remove(board));
 
             fake_context.Setup(c => c.Boards).Returns(mock_boards_set.Object); // Context.Boards returns fake_board_table (a list)
+            //fake_context.Setup(c => c.SaveChanges()).Verifiable().Returns(0); Verifiable returns void. Make PR
+            fake_context.Setup(c => c.SaveChanges()).Returns(0).Verifiable();
         }
 
         [TestMethod]
@@ -159,6 +161,24 @@ namespace FakeTrello.Tests.DAL
             // Assert
             Assert.AreEqual(expected_board_count, actual_board_count);
 
+        }
+
+        [TestMethod]
+        public void EnsureICanEditBoardName()
+        {
+            // Arrange
+            fake_board_table.Add(new Board { BoardId = 1, Name = "My Board", Owner = sally });
+            CreateFakeDatabase();
+
+            // Act
+            string expected_board_name = "Our Board";
+            repo.EditBoardName(1, expected_board_name);
+            string actual_board_name = repo.GetBoard(1).Name;
+
+            // Assert
+            Assert.AreEqual(expected_board_name, actual_board_name);
+            fake_context.Verify(c => c.SaveChanges(), Times.Once());
+            
         }
     }
 }

--- a/FakeTrello/DAL/FakeTrelloRepository.cs
+++ b/FakeTrello/DAL/FakeTrelloRepository.cs
@@ -138,5 +138,16 @@ namespace FakeTrello.DAL
         {
             throw new NotImplementedException();
         }
+
+        public void EditBoardName(int boardId, string newname)
+        {
+            Board found_board = GetBoard(boardId);
+            if (found_board != null)
+            {
+                found_board.Name = newname; // Akin to 'git add'
+                Context.SaveChanges(); // Akin to 'git commit'
+            }
+            // False Positive: SaveChanges is missing.
+        }
     }
 }

--- a/FakeTrello/DAL/IRepository.cs
+++ b/FakeTrello/DAL/IRepository.cs
@@ -31,6 +31,7 @@ namespace FakeTrello.DAL
         bool AttachUser(string userId, int cardId); // true: successful, false: not successful
         bool MoveCard(int cardId, int oldListId, int newListId);
         bool CopyCard(int cardId, int newListId, string newOwnerId);
+        void EditBoardName(int boardId, string newname);
 
         // Delete
         bool RemoveBoard(int boardId);


### PR DESCRIPTION
This Pull Request covers a few items:

1. We added a new method `EditBoardName` to our `IRepository` interface **and** `FakeTrelloRepository`.
2. [Wrote a test](https://github.com/nss-evening-cohort-04/FakeTrello/compare/lecture_mar_18?expand=1#diff-3b50e12d7ecac1ed077c8d3d788509deR167) for edit functionality.
3. [Implemented the method for edit](https://github.com/nss-evening-cohort-04/FakeTrello/compare/lecture_mar_18?expand=1#diff-d8f80621ab34be6c77f1d8d58789a1ccR142)
4. [Located a bug](https://github.com/nss-evening-cohort-04/FakeTrello/compare/lecture_mar_18?expand=1#diff-3b50e12d7ecac1ed077c8d3d788509deR50) in [Moq4's documentation](http://www.nudoq.org/#!/Packages/Moq/Moq/Mock/M/Verify).
5. Updated CreateFakeDatabase to [mock calls to SaveChanges](https://github.com/nss-evening-cohort-04/FakeTrello/compare/lecture_mar_18?expand=1#diff-3b50e12d7ecac1ed077c8d3d788509deR51) to ensure it is called given the testing false positive.
6. Called [Moq's Verify method](https://github.com/nss-evening-cohort-04/FakeTrello/compare/lecture_mar_18?expand=1#diff-3b50e12d7ecac1ed077c8d3d788509deR180) to [ensure SaveChanges is called when editing a Board name](https://github.com/nss-evening-cohort-04/FakeTrello/compare/lecture_mar_18?expand=1#diff-d8f80621ab34be6c77f1d8d58789a1ccR148).